### PR TITLE
Changed url to Wordpress link, not GUID

### DIFF
--- a/R/get-wp-posts.R
+++ b/R/get-wp-posts.R
@@ -38,7 +38,7 @@ get_wp_posts <- function(root_url, post_count = Inf,after_date = NULL) {
         return(posts_real)
       }
       for(k in 1:length(response)) {
-        response_df <- tibble(id = response[[k]]$id, date = response[[k]]$date, url = response[[k]]$guid$rendered,
+        response_df <- tibble(id = response[[k]]$id, date = response[[k]]$date, url = response[[k]]$link,
                               title = response[[k]]$title$rendered, content = response[[k]]$content$rendered,
                               author = response[[k]]$author)
         response_tags <- c()
@@ -84,7 +84,7 @@ get_wp_posts <- function(root_url, post_count = Inf,after_date = NULL) {
       }
       if(length(response) > 0 & response[[3]]$status != 400) {
         for(k in 1:length(response)) {
-          response_df <- tibble(id = response[[k]]$id, date = response[[k]]$date, url = response[[k]]$guid$rendered,
+          response_df <- tibble(id = response[[k]]$id, date = response[[k]]$date, url = response[[k]]$link,
                                 title = response[[k]]$title$rendered, content = response[[k]]$content$rendered,
                                 author = response[[k]]$author)
           response_tags <- c()


### PR DESCRIPTION
I think it makes more sense for the URL to be the post.link, rather than the post.GUID. 

The REST documentation refers to the link as the post URL:

https://developer.wordpress.org/rest-api/reference/posts/

If the GUID was also needed, then I think that could also be included as $guid in the tiddle that is returned. 
